### PR TITLE
Deprecation notice fixed: Using ${var} in strings is deprecated, use {$var} instead

### DIFF
--- a/bin/tokencrypt-cmd
+++ b/bin/tokencrypt-cmd
@@ -12,7 +12,7 @@ foreach($autoloads as $autoload) {
 }
 
 if ($argc == 2 && $argv[1] == '-h') {
-    echo "Usage: ${argv[0]} [file with secrets]\n";
+    echo "Usage: {$argv[0]} [file with secrets]\n";
     echo "       if file not exists, tool tries to launch in interactive mode\n";
     echo "       supported file formats:\n";
     echo "       - 3 lines, 1st line - secret, 2nd line - salt, 3rd line - rounds\n";
@@ -126,7 +126,7 @@ function initInteractive(): TokenCrypt {
 
 function initFromFile($fileName): TokenCrypt {
     if (!file_exists($fileName)) {
-        echo "file ${fileName} not exists\n";
+        echo "file {$fileName} not exists\n";
         exit(1);
     }
 


### PR DESCRIPTION
Get rid of annoying notice