### PR TITLE
Add raw 32-byte key factory (TokenCrypt::fromRawKey)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,41 @@ This is a PHP 7.2+ implementation.
 
 ## Usage
 
+### Recommended: raw 32-byte key
+
+Pass a 32-byte binary string containing an AES-256 key. Derive it however you prefer —
+for passwords use Argon2id; for high-entropy inputs (random keys, API tokens) a single
+SHA3-256 hash is sufficient.
+
+```php
+$key = random_bytes(32);                              // or: load from env / secret store
+$tokenCrypt = \ThreeEncr\TokenCrypt::fromRawKey($key);
+```
+
+### Legacy: PBKDF2-SHA3 constructor
+
+The original `(secret, salt, iterations)` constructor is kept for backward compatibility
+with data encrypted by earlier versions. It is deprecated — prefer `fromRawKey()` above
+for new code.
 
 ```php
 $tokenCrypt = new \ThreeEncr\TokenCrypt($secret, $salt, 1000);
 ```
 
-`$secret` and `$salt` - are encryption keys (technically one of them is key, another is salt, but you need to store them both somewhere, 
-preferably in different places). 
+`$secret` and `$salt` are inputs to PBKDF2-SHA3 (one of them is key, the other is salt,
+but you need to store them both somewhere, preferably in different places).
 
-You can store them any preferred places: environment variables, files, shared memory, 
-drive from serial numbers or MAC. Be creative. 
+You can store them in any preferred places: environment variables, files, shared memory,
+derived from serial numbers or MAC. Be creative.
 
-`1000` - is a number of PBKDF2 rounds. 
-The more is slower. 
-If you are sure that your secrets have 256 bit of entropy and fairly random, you can use '1' (essentially HMAC SHA3 hash)
+`1000` is the number of PBKDF2 rounds. Higher is slower and more resistant to
+brute-force. If you are sure your secrets have 256 bits of entropy and are fairly random,
+you can use `1` (essentially a single HMAC SHA3 hash).
 
-After you created the class instance, you can just use encrypt3ncr and decrypt3ncr methods (they accept and return strings):
+### Encrypt / decrypt
+
+After you created the class instance, you can use `encrypt3ncr` and `decrypt3ncr` methods
+(they accept and return strings):
 
 ```php
 $token = '08019215-B205-4416-B2FB-132962F9952F'; // your secret you want to encrypt 

--- a/src/TokenCrypt.php
+++ b/src/TokenCrypt.php
@@ -7,17 +7,47 @@ use \Exception;
 class TokenCrypt implements JsonSerializable
 {
     public const HEADER_V1 = '3ncr.org/1#';
+    public const KEY_SIZE = 32;
     private $key;
 
     /**
-     * TokenCrypt constructor.
+     * TokenCrypt constructor (legacy PBKDF2-SHA3 KDF).
+     *
      * @param $secret - secret for encryption
      * @param $salt - salt for encryption
      * @param int $iter - number of PBKDF2 iterations
+     * @deprecated PBKDF2-SHA3 is the legacy KDF. Derive your own 32-byte key and
+     *             pass it to self::fromRawKey() (Argon2id for passwords, SHA3-256
+     *             for high-entropy inputs — see 3ncr.org spec).
      */
     public function __construct(string $secret, string $salt, int $iter=1000)
     {
         $this->key = hash_pbkdf2('sha3-256', $secret, $salt, $iter, 0, true);
+    }
+
+    /**
+     * Creates a TokenCrypt instance from a raw 32-byte AES-256 key.
+     *
+     * Derive the key however you prefer — Argon2id for passwords, a single
+     * SHA3-256 hash for high-entropy inputs (random keys, API tokens). See the
+     * 3ncr.org spec for recommended parameters.
+     *
+     * @param string $key - raw 32-byte key (binary string)
+     * @throws TokenCryptException if $key is not exactly KEY_SIZE bytes
+     */
+    public static function fromRawKey(string $key): self
+    {
+        $len = strlen($key);
+        if ($len !== self::KEY_SIZE) {
+            throw new TokenCryptException(sprintf(
+                'Raw key must be exactly %d bytes, got %d',
+                self::KEY_SIZE,
+                $len
+            ));
+        }
+        $instance = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        $instance->key = $key;
+        return $instance;
     }
 
     /**

--- a/tests/TokenCryptTest.php
+++ b/tests/TokenCryptTest.php
@@ -4,6 +4,7 @@ namespace ThreeEncr\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ThreeEncr\TokenCrypt;
+use ThreeEncr\TokenCryptException;
 
 class TokenCryptTest extends TestCase
 {
@@ -80,5 +81,57 @@ class TokenCryptTest extends TestCase
         $this->assertNull($t->decrypt3ncr($fail));
         $t = new TokenCrypt('a', 'c', 1000);
         $this->assertNull($t->decrypt3ncr($encs[0]));
+    }
+
+    public function testFromRawKeyDecryptsCanonicalVectors()
+    {
+        $rawKey = hash_pbkdf2('sha3-256', 'a', 'b', 1000, 0, true);
+        $t = TokenCrypt::fromRawKey($rawKey);
+
+        foreach ($this->testVectors as $k => $v) {
+            $this->assertEquals($v, $t->decrypt3ncr($k));
+        }
+    }
+
+    public function testFromRawKeyIdentity()
+    {
+        $rawKey = random_bytes(32);
+        $t = TokenCrypt::fromRawKey($rawKey);
+
+        foreach (array_values($this->testVectors) as $src) {
+            $enc = $t->encrypt3ncr($src);
+            $dec = $t->decrypt3ncr($enc);
+            $this->assertEquals($src, $dec);
+        }
+    }
+
+    public function testFromRawKeyInteropWithLegacyConstructor()
+    {
+        $legacy = new TokenCrypt('a', 'b', 1000);
+        $rawKey = hash_pbkdf2('sha3-256', 'a', 'b', 1000, 0, true);
+        $raw = TokenCrypt::fromRawKey($rawKey);
+
+        foreach (array_values($this->testVectors) as $src) {
+            $this->assertEquals($src, $raw->decrypt3ncr($legacy->encrypt3ncr($src)));
+            $this->assertEquals($src, $legacy->decrypt3ncr($raw->encrypt3ncr($src)));
+        }
+    }
+
+    public function testFromRawKeyRejectsShortKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey(str_repeat("\x00", 31));
+    }
+
+    public function testFromRawKeyRejectsLongKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey(str_repeat("\x00", 33));
+    }
+
+    public function testFromRawKeyRejectsEmptyKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey('');
     }
 }


### PR DESCRIPTION
## Summary
- Add `TokenCrypt::fromRawKey(string $key): self` — constructs an instance from a raw 32-byte AES-256 key without running PBKDF2
- Mark the existing `__construct(secret, salt, iter)` as `@deprecated`; it stays to decrypt data produced by earlier versions
- Documents the recommended usage (Argon2id for passwords, SHA3-256 for high-entropy inputs) in the README

This is the PHP half of [PLAN.md §1 "Library changes"](../blob/master/PLAN.md#L28-L35); the Node.js equivalent shipped in nodencrypt#1.

The factory bypasses the public constructor via `ReflectionClass::newInstanceWithoutConstructor()` so there's no wasted PBKDF2 call. A `KEY_SIZE = 32` constant is added alongside `HEADER_V1`.

## Test plan
- [x] `composer run-script test` — 11/11 pass on PHP 8.4 (5 existing + 6 new)
- [x] `composer run-script lint` — clean
- [x] New tests cover: decrypt of canonical v1 vectors via a PBKDF2-derived key passed to `fromRawKey`; encrypt/decrypt identity with a random 32-byte key; legacy ↔ raw-key interop (each instance decrypts what the other encrypts); rejection of 0/31/33-byte keys with `TokenCryptException`
- [ ] GitHub Actions matrix (7.2, 7.4, 8.0, 8.1, 8.2) — will run on push