### PR TITLE
Add Argon2id factory (TokenCrypt::fromArgon2id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,41 @@ This is a PHP 7.2+ implementation.
 
 ## Usage
 
+### Recommended: raw 32-byte key
+
+Pass a 32-byte binary string containing an AES-256 key. Derive it however you prefer —
+for passwords use Argon2id; for high-entropy inputs (random keys, API tokens) a single
+SHA3-256 hash is sufficient.
+
+```php
+$key = random_bytes(32);                              // or: load from env / secret store
+$tokenCrypt = \ThreeEncr\TokenCrypt::fromRawKey($key);
+```
+
+### Legacy: PBKDF2-SHA3 constructor
+
+The original `(secret, salt, iterations)` constructor is kept for backward compatibility
+with data encrypted by earlier versions. It is deprecated — prefer `fromRawKey()` above
+for new code.
 
 ```php
 $tokenCrypt = new \ThreeEncr\TokenCrypt($secret, $salt, 1000);
 ```
 
-`$secret` and `$salt` - are encryption keys (technically one of them is key, another is salt, but you need to store them both somewhere, 
-preferably in different places). 
+`$secret` and `$salt` are inputs to PBKDF2-SHA3 (one of them is key, the other is salt,
+but you need to store them both somewhere, preferably in different places).
 
-You can store them any preferred places: environment variables, files, shared memory, 
-drive from serial numbers or MAC. Be creative. 
+You can store them in any preferred places: environment variables, files, shared memory,
+derived from serial numbers or MAC. Be creative.
 
-`1000` - is a number of PBKDF2 rounds. 
-The more is slower. 
-If you are sure that your secrets have 256 bit of entropy and fairly random, you can use '1' (essentially HMAC SHA3 hash)
+`1000` is the number of PBKDF2 rounds. Higher is slower and more resistant to
+brute-force. If you are sure your secrets have 256 bits of entropy and are fairly random,
+you can use `1` (essentially a single HMAC SHA3 hash).
 
-After you created the class instance, you can just use encrypt3ncr and decrypt3ncr methods (they accept and return strings):
+### Encrypt / decrypt
+
+After you created the class instance, you can use `encrypt3ncr` and `decrypt3ncr` methods
+(they accept and return strings):
 
 ```php
 $token = '08019215-B205-4416-B2FB-132962F9952F'; // your secret you want to encrypt 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "require" : {
     "php" : ">=7.2.0",
     "ext-openssl" : "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-sodium": "*"
   },
   "autoload" : {
     "psr-4" : { "ThreeEncr\\" : "src" }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "683cf3981583aa25b36eb87e65181f42",
+    "content-hash": "0e1b6103c78499116dfb51f7dacf549a",
     "packages": [],
     "packages-dev": [
         {
@@ -3267,7 +3267,8 @@
     "platform": {
         "php": ">=7.2.0",
         "ext-openssl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-sodium": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/TokenCrypt.php
+++ b/src/TokenCrypt.php
@@ -8,6 +8,13 @@ class TokenCrypt implements JsonSerializable
 {
     public const HEADER_V1 = '3ncr.org/1#';
     public const KEY_SIZE = 32;
+
+    // 3ncr.org recommended Argon2id parameters for interoperability
+    // (see https://3ncr.org/1/ - Key Derivation section).
+    public const ARGON2ID_MEMORY_KIB = 19456;
+    public const ARGON2ID_TIME_COST = 2;
+    public const ARGON2ID_SALT_BYTES = 16;
+
     private $key;
 
     /**
@@ -48,6 +55,44 @@ class TokenCrypt implements JsonSerializable
         $instance = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
         $instance->key = $key;
         return $instance;
+    }
+
+    /**
+     * Creates a TokenCrypt instance using the 3ncr.org recommended Argon2id
+     * KDF for low-entropy secrets (passwords, passphrases). Parameters follow
+     * the spec (https://3ncr.org/1/ - Key Derivation): memory 19456 KiB,
+     * iterations 2, parallelism 1, output 32 bytes.
+     *
+     * Uses libsodium's crypto_pwhash, which requires a salt of exactly 16
+     * bytes. This matches the spec's "at least 16 random bytes" recommendation
+     * at its minimum length and is interoperable with Argon2id keys derived by
+     * the Go and Node implementations when the same 16-byte salt is used.
+     *
+     * @param string $secret - secret / passphrase to derive the key from
+     * @param string $salt - salt, must be exactly 16 bytes
+     * @throws TokenCryptException if ext-sodium is missing or $salt length is wrong
+     */
+    public static function fromArgon2id(string $secret, string $salt): self
+    {
+        if (!function_exists('sodium_crypto_pwhash')) {
+            throw new TokenCryptException('ext-sodium is required for Argon2id key derivation');
+        }
+        if (strlen($salt) !== self::ARGON2ID_SALT_BYTES) {
+            throw new TokenCryptException(sprintf(
+                'Argon2id salt must be exactly %d bytes, got %d',
+                self::ARGON2ID_SALT_BYTES,
+                strlen($salt)
+            ));
+        }
+        $key = sodium_crypto_pwhash(
+            self::KEY_SIZE,
+            $secret,
+            $salt,
+            self::ARGON2ID_TIME_COST,
+            self::ARGON2ID_MEMORY_KIB * 1024,
+            SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13
+        );
+        return self::fromRawKey($key);
     }
 
     /**

--- a/src/TokenCrypt.php
+++ b/src/TokenCrypt.php
@@ -7,17 +7,47 @@ use \Exception;
 class TokenCrypt implements JsonSerializable
 {
     public const HEADER_V1 = '3ncr.org/1#';
+    public const KEY_SIZE = 32;
     private $key;
 
     /**
-     * TokenCrypt constructor.
+     * TokenCrypt constructor (legacy PBKDF2-SHA3 KDF).
+     *
      * @param $secret - secret for encryption
      * @param $salt - salt for encryption
      * @param int $iter - number of PBKDF2 iterations
+     * @deprecated PBKDF2-SHA3 is the legacy KDF. Derive your own 32-byte key and
+     *             pass it to self::fromRawKey() (Argon2id for passwords, SHA3-256
+     *             for high-entropy inputs — see 3ncr.org spec).
      */
     public function __construct(string $secret, string $salt, int $iter=1000)
     {
         $this->key = hash_pbkdf2('sha3-256', $secret, $salt, $iter, 0, true);
+    }
+
+    /**
+     * Creates a TokenCrypt instance from a raw 32-byte AES-256 key.
+     *
+     * Derive the key however you prefer — Argon2id for passwords, a single
+     * SHA3-256 hash for high-entropy inputs (random keys, API tokens). See the
+     * 3ncr.org spec for recommended parameters.
+     *
+     * @param string $key - raw 32-byte key (binary string)
+     * @throws TokenCryptException if $key is not exactly KEY_SIZE bytes
+     */
+    public static function fromRawKey(string $key): self
+    {
+        $len = strlen($key);
+        if ($len !== self::KEY_SIZE) {
+            throw new TokenCryptException(sprintf(
+                'Raw key must be exactly %d bytes, got %d',
+                self::KEY_SIZE,
+                $len
+            ));
+        }
+        $instance = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        $instance->key = $key;
+        return $instance;
     }
 
     /**

--- a/tests/TokenCryptTest.php
+++ b/tests/TokenCryptTest.php
@@ -134,4 +134,52 @@ class TokenCryptTest extends TestCase
         $this->expectException(TokenCryptException::class);
         TokenCrypt::fromRawKey('');
     }
+
+    public function testFromArgon2idIdentity()
+    {
+        $t = TokenCrypt::fromArgon2id('correct horse battery staple', '0123456789abcdef');
+
+        foreach (array_values($this->testVectors) as $src) {
+            $enc = $t->encrypt3ncr($src);
+            $dec = $t->decrypt3ncr($enc);
+            $this->assertEquals($src, $dec);
+        }
+    }
+
+    public function testFromArgon2idWrongSecretFails()
+    {
+        $salt = '0123456789abcdef';
+        $right = TokenCrypt::fromArgon2id('right secret', $salt);
+        $enc = $right->encrypt3ncr('hello');
+
+        $wrong = TokenCrypt::fromArgon2id('wrong secret', $salt);
+        $this->assertNull($wrong->decrypt3ncr($enc));
+    }
+
+    public function testFromArgon2idMatchesKnownKey()
+    {
+        // Cross-checked against Go (argon2.IDKey) and Node (hash-wasm argon2id)
+        // with the same secret/salt/params: same derived 32-byte key.
+        $expected = hex2bin('832e52b959b967b570ee4781f6c7bda7ced019ca266ac781fd2d94d4e853b0cd');
+        $t = TokenCrypt::fromArgon2id('correct horse battery staple', '0123456789abcdef');
+        $rawEquivalent = TokenCrypt::fromRawKey($expected);
+
+        $enc = $t->encrypt3ncr('interop');
+        $this->assertEquals('interop', $rawEquivalent->decrypt3ncr($enc));
+
+        $enc2 = $rawEquivalent->encrypt3ncr('interop');
+        $this->assertEquals('interop', $t->decrypt3ncr($enc2));
+    }
+
+    public function testFromArgon2idRejectsShortSalt()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromArgon2id('secret', 'short');
+    }
+
+    public function testFromArgon2idRejectsLongSalt()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromArgon2id('secret', str_repeat('x', 17));
+    }
 }

--- a/tests/TokenCryptTest.php
+++ b/tests/TokenCryptTest.php
@@ -4,6 +4,7 @@ namespace ThreeEncr\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ThreeEncr\TokenCrypt;
+use ThreeEncr\TokenCryptException;
 
 class TokenCryptTest extends TestCase
 {
@@ -80,5 +81,57 @@ class TokenCryptTest extends TestCase
         $this->assertNull($t->decrypt3ncr($fail));
         $t = new TokenCrypt('a', 'c', 1000);
         $this->assertNull($t->decrypt3ncr($encs[0]));
+    }
+
+    public function testFromRawKeyDecryptsCanonicalVectors()
+    {
+        $rawKey = hash_pbkdf2('sha3-256', 'a', 'b', 1000, 0, true);
+        $t = TokenCrypt::fromRawKey($rawKey);
+
+        foreach ($this->testVectors as $k => $v) {
+            $this->assertEquals($v, $t->decrypt3ncr($k));
+        }
+    }
+
+    public function testFromRawKeyIdentity()
+    {
+        $rawKey = random_bytes(32);
+        $t = TokenCrypt::fromRawKey($rawKey);
+
+        foreach (array_values($this->testVectors) as $src) {
+            $enc = $t->encrypt3ncr($src);
+            $dec = $t->decrypt3ncr($enc);
+            $this->assertEquals($src, $dec);
+        }
+    }
+
+    public function testFromRawKeyInteropWithLegacyConstructor()
+    {
+        $legacy = new TokenCrypt('a', 'b', 1000);
+        $rawKey = hash_pbkdf2('sha3-256', 'a', 'b', 1000, 0, true);
+        $raw = TokenCrypt::fromRawKey($rawKey);
+
+        foreach (array_values($this->testVectors) as $src) {
+            $this->assertEquals($src, $raw->decrypt3ncr($legacy->encrypt3ncr($src)));
+            $this->assertEquals($src, $legacy->decrypt3ncr($raw->encrypt3ncr($src)));
+        }
+    }
+
+    public function testFromRawKeyRejectsShortKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey(str_repeat("\x00", 31));
+    }
+
+    public function testFromRawKeyRejectsLongKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey(str_repeat("\x00", 33));
+    }
+
+    public function testFromRawKeyRejectsEmptyKey()
+    {
+        $this->expectException(TokenCryptException::class);
+        TokenCrypt::fromRawKey('');
     }
 }


### PR DESCRIPTION
## Summary

Adds `TokenCrypt::fromArgon2id(string $secret, string $salt)` static factory that derives an AES-256 key using the 3ncr.org-recommended Argon2id KDF (see [Key Derivation](https://3ncr.org/1/#kdf)). This is the PHP counterpart to Go's `NewArgon2idTokenCrypt` and Node's `NodenCrypt.fromArgon2id`.

Parameters follow the spec:
- memory cost: 19456 KiB
- time cost: 2 iterations
- parallelism: 1
- output: 32 bytes

Implemented via `ext-sodium`'s `sodium_crypto_pwhash` with `SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13`. Cross-verified that the derived key bytes match Go's `argon2.IDKey` for the same inputs.

Depends on #3 (the raw-key factory) — built off that branch and reuses `fromRawKey` internally.

### Note on salt length

libsodium's `crypto_pwhash` requires the salt to be exactly 16 bytes (the spec says "at least 16"). The PHP implementation enforces exactly 16. A 16-byte salt is interoperable with Go and Node.

### Changes

- `src/TokenCrypt.php`: `fromArgon2id` factory + class constants for the Argon2id parameters.
- `composer.json`: adds `ext-sodium` to `require`.
- `tests/TokenCryptTest.php`: identity round-trip, wrong-secret failure, cross-language known-key interop check, and salt-length validation.

## Test plan

- [x] `composer test` passes (16 tests, 40 assertions)
- [x] `composer lint` passes
- [x] Known-key test confirms the derived key matches the value produced by Go's `argon2.IDKey` for the same inputs (`832e52b9…b0cd`)