### PR TITLE
Release v2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "3ncr/tokencrypt-php",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "Implementation of 3ncr.org V1 token(strings) encryption standard.",
   "bin": ["bin/tokencrypt-cmd"],


### PR DESCRIPTION
Bumps the `composer.json` version field to `2.0.0` in preparation for
tagging a new release.

Changes since v1.0.6:

**Breaking**
- Minimum PHP raised from 7.2 to 8.1 (#5)

**Added**
- `TokenCrypt::fromRawKey(string $key)` — raw 32-byte AES key factory (#3)
- `TokenCrypt::fromArgon2id(string $secret, string $salt)` — Argon2id KDF factory (#4)

**Changed**
- PHPUnit bumped from ^8.5 to ^10.5 (#6)
- CI matrix now tests PHP 8.1, 8.2, 8.3, 8.4, 8.5 (#5)

**Deprecated**
- `new TokenCrypt($secret, $salt, $iterations)` (PBKDF2-SHA3) — kept for
  decrypting existing data (#3)

The wire format (`3ncr.org/1#<base64(iv + ciphertext + tag)>`) is unchanged.

Once merged, tag `v2.0.0` on the resulting master commit and publish a
GitHub release.