### PR TITLE
ci: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with weekly checks for:

- `composer` — PHP package dependencies (root `/`)
- `github-actions` — GHA workflow action versions (root `/`)

Both ecosystems are capped at 5 concurrent open PRs to avoid noise.

## Why

Continues the §5d trustworthiness sweep in `PLAN.md` (Per-repo workflow changes). Mirrors the pattern already landed in `tokencrypt` PR #9 and `nodencrypt` PR #14. Pairs with the upcoming SHA-pinning of GitHub Actions: once each `uses:` line is pinned to a 40-char commit SHA, Dependabot's `github-actions` ecosystem keeps the versions current without anyone having to remember to bump tags.

## Test plan

- [ ] After merge, confirm Dependabot shows up under repo Insights → Dependency graph → Dependabot
- [ ] Verify it queues an update PR within ~24h if any `composer` or `actions/*` version is stale