### PR TITLE
ci: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -16,10 +16,10 @@ jobs:
     name: PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: ${{ matrix.php-version }}
 
@@ -28,7 +28,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php-version }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
## Summary

Pin each `uses:` in `.github/workflows/lint-and-test.yml` to a 40-char commit SHA, with a version comment:

- `actions/checkout` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `shivammathur/setup-php` → `accd6127cb78bee3e8082180cb391013d204ef9f` (2.37.0)
- `actions/cache` → `0400d5f644dc74513175e3cd8d07132dd4860809` (v4.2.4)

## Why

Floating tags (`v3`, `v2`) can be force-pushed to a malicious commit; a 40-char SHA cannot. Third repo in the cross-repo §5d "Pin GitHub Actions by SHA" sweep in `PLAN.md`, following tokencrypt#10 and nodencrypt#16.

Also bumps `actions/checkout` and `actions/cache` from v3 to v4 to align with the other repos' SHA pins, so Dependabot (queued in #10) has less catch-up work.

Pairs with the Dependabot config in #10 — once that lands, Dependabot's `github-actions` ecosystem keeps the SHAs fresh automatically.

## Test plan

- [ ] CI runs green on this PR (PHP 8.1–8.5 matrix, same checks as master)
- [ ] Workflow still exercises the same tests, just with pinned action versions