### PR TITLE
ci: add OpenSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: Scorecard supply-chain security
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Lint & Test](https://github.com/3ncr/tokencrypt-php/actions/workflows/lint-and-test.yml/badge.svg)](https://github.com/3ncr/tokencrypt-php/actions/workflows/lint-and-test.yml)
 [![Latest Stable Version](https://poser.pugx.org/3ncr/tokencrypt-php/v/stable)](https://packagist.org/packages/3ncr/tokencrypt-php)
 [![Total Downloads](https://poser.pugx.org/3ncr/tokencrypt-php/downloads)](https://packagist.org/packages/3ncr/tokencrypt-php)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/3ncr/tokencrypt-php/badge)](https://scorecard.dev/viewer/?uri=github.com/3ncr/tokencrypt-php)
 [![License: MIT](https://poser.pugx.org/3ncr/tokencrypt-php/license)](https://packagist.org/packages/3ncr/tokencrypt-php)
 
 [3ncr.org](https://3ncr.org/) is a standard for string encryption / decryption


### PR DESCRIPTION
Adds the [OpenSSF Scorecard](https://github.com/ossf/scorecard) GitHub Actions workflow and a badge in the README. Runs on every push to `master` and weekly on Saturdays; publishes the run to `scorecard.dev` and uploads SARIF to the repo's Code Scanning dashboard.

### Why

Scorecard audits the repo against ~20 supply-chain security signals (pinned actions, branch protection, SECURITY.md, SAST, token permissions, etc.) and surfaces a 0–10 score plus a badge. For a crypto library the badge doubles as a third-party trust signal for downstream users; for us the score itself is a useful todo list for the remaining §5d items.

### What's in the diff

- `.github/workflows/scorecard.yml` — canonical OSSF workflow with SHA-pinned actions matching the rest of the repo.
- `README.md` — new badge slot (between Downloads and License) linking to `scorecard.dev/viewer/?uri=github.com/3ncr/tokencrypt-php`.

### Notes

- The workflow's token permissions are minimized (`permissions: read-all` at the workflow level, `security-events: write` + `id-token: write` only on the analysis job).
- The badge endpoint will 404 until the first scheduled run completes; the button settles within a day.
- Third in the per-repo sweep after tokencrypt#17 and nodencrypt#23. See `PLAN.md` §5d.