### PR TITLE
docs: link to github.com/3ncr for other-language implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ authenticated encryption with a 12-byte random IV:
 Encrypted values look like
 `3ncr.org/1#pHRufQld0SajqjHx+FmLMcORfNQi1d674ziOPpG52hqW5+0zfJD91hjXsBsvULVtB017mEghGy3Ohj+GgQY5MQ`.
 
-This is the PHP 8.1+ implementation.
+This is the PHP 8.1+ implementation. See
+[github.com/3ncr](https://github.com/3ncr) for implementations in other
+languages (Go, Node.js, Python, Rust, Java, C#, Ruby).
 
 ## Install
 


### PR DESCRIPTION
Adds a one-line pointer from the PHP README to the
[3ncr org profile](https://github.com/3ncr), which is the single source
of truth for the cross-language implementations matrix (Go, Node.js, PHP,
Python, Rust, Java, C#, Ruby).

Per PLAN.md §5c: keeping the implementations matrix only on the org
profile eliminates per-repo drift.

Third of eight identical docs-only PRs — one per library.