### PR TITLE
ci: auto-merge dependabot patch/minor and action bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge (patch/minor and all action bumps)
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` that inspects each dependabot PR via `dependabot/fetch-metadata` and enables GitHub's `--auto` merge for non-major updates.
- Major version bumps still require manual review.
- The merge is still gated by the existing required status checks on the default branch — CI must pass before it actually lands.

## Test plan
- [ ] Workflow file parses (GitHub Actions lints on push)
- [ ] On the next dependabot PR, confirm the `Dependabot auto-merge` workflow runs and the PR gets auto-merged once CI passes.
- [ ] Confirm major bumps (when one arrives) do **not** auto-merge.